### PR TITLE
Speedup

### DIFF
--- a/occult/occult.py
+++ b/occult/occult.py
@@ -1,6 +1,5 @@
 # Standard libs
 import math
-from pstats import SortKey
 from typing import Dict, List, Optional, Tuple, Union
 
 # Third party libs

--- a/occult/occult.py
+++ b/occult/occult.py
@@ -1,5 +1,4 @@
 # Standard libs
-import cProfile
 import math
 from pstats import SortKey
 from typing import Dict, List, Optional, Tuple, Union
@@ -11,7 +10,6 @@ import vpype
 from shapely.geometry import LineString, Polygon
 from shapely.geometry.multilinestring import MultiLineString
 from shapely.strtree import STRtree
-from tqdm import tqdm
 from vpype import LengthType, LineCollection, global_processor, multiple_to_layer_ids
 
 
@@ -56,7 +54,7 @@ def _occult_layer(
     tree = STRtree(line_arr_lines)
     index_by_id = dict((id(pt), i) for i, pt in enumerate(line_arr_lines))
 
-    for i, (l_id, line) in enumerate(tqdm(line_arr)):
+    for i, (l_id, line) in enumerate(line_arr):
         coords = np.array(line.coords)
 
         if not (
@@ -158,8 +156,6 @@ def occult(
     new_document = document.empty_copy()
     layer_ids = multiple_to_layer_ids(layer, document)
     removed_layer_id = document.free_id()
-    pr = cProfile.Profile()
-    pr.enable()
 
     if ignore_layers:
         layers = [{l_id: list(document.layers_from_ids([l_id]))[0] for l_id in layer_ids}]
@@ -175,10 +171,6 @@ def occult(
         if keep_occulted and not removed_lines.is_empty():
             new_document.add(removed_lines, layer_id=removed_layer_id)
 
-    pr.disable()
-    pr.create_stats()
-    pr.dump_stats("../pr-dump.stats")
-    # gprof2dot -f pstats pr-dump | dot -Tpng -o profile-out.png
     return new_document
 
 

--- a/occult/occult.py
+++ b/occult/occult.py
@@ -52,6 +52,10 @@ def _occult_layer(
         line_arr.extend([[l_id, line] for line in lines.as_mls()])
         line_arr_lines.extend([line for line in lines.as_mls()])
 
+    # Build R-tree from previous geometries
+    tree = STRtree(line_arr_lines)
+    index_by_id = dict((id(pt), i) for i, pt in enumerate(line_arr_lines))
+
     for i, (l_id, line) in enumerate(tqdm(line_arr)):
         coords = np.array(line.coords)
 
@@ -62,10 +66,9 @@ def _occult_layer(
         ):
             continue
 
-        # Build R-tree from previous geometries
-        tree = STRtree(line_arr_lines[:i])
         p = Polygon(coords)
-        geom_idx = [line_arr_lines.index(g) for g in tree.query(p)]
+        geom_idx = [index_by_id[id(g)] for g in tree.query(p)]
+        geom_idx = [idx for idx in geom_idx if idx < i]
 
         for gi in geom_idx:
             # Aggregate removed lines


### PR DESCRIPTION
Use a hashmap instead of `.index(g)` to get geometries indices (as advised in shapely doc).
Create a single RTree
