### PR TITLE
Ignore non valid polygons

### DIFF
--- a/occult/occult.py
+++ b/occult/occult.py
@@ -63,6 +63,10 @@ def _occult_layer(
             continue
 
         p = Polygon(coords)
+
+        if not p.is_valid:
+            continue
+
         geom_idx = [index_by_id[id(g)] for g in tree.query(p)]
         geom_idx = [idx for idx in geom_idx if idx < i]
 


### PR DESCRIPTION
This prevents issues when we encounter invalid polygons (https://shapely.readthedocs.io/en/stable/manual.html#polygons)

This only ignore the invalid polygons to prevent a fatal crash but ideally we should handle them properly.

The stack-trace of the bug:

```
Input geom 1 is INVALID: Self-intersection at or near point 684.03487592166005 192.61610852966831 (684.03487592166004561 192.61610852966830976)
<A>
POLYGON ((684.0349999999999682 192.6160000000000139, 683.6999040000001742 192.9091040000000703, 683.3565520000000788 193.2009120000000166, 683.0132479999998623 193.4903680000000463, 682.6782960000000458 193.7764160000000402, 682.3600000000000136 194.0580000000000211, 682.0120000000000573 194.3260000000000218, 681.6851399864157202 194.5932200703519754, 681.3564951572985819 194.8582419765669442, 681.0260802952320773 195.1210537978474520, 680.6939102624163525 195.3816437128066639, 680.3600000000000136 195.6400000000000148, 680.1630000000000109 195.7900000000000205, 679.7825781250001000 196.0693906250000396, 679.4056249999999864 196.3473749999999995, 679.0266093750000209 196.6229218750000030, 678.6399999999999864 196.8950000000000102, 678.0699999999999363 197.2909999999999968, 677.7349040000000286 197.5267600000000527, 677.3915519999999333 197.7603600000000199, 677.0482479999998304 197.9922799999999938, 676.7132960000000139 198.2230000000000132, 676.3949999999999818 198.4530000000000030, 675.7909999999999400 198.8259999999999934, 675.4065925925925740 199.0771111111111225, 675.0197407407406445 199.3182222222222322, 674.6279999999999291 199.5459999999999923, 674.2612222222221590 199.7630370370370940, 673.9251111111110504 199.9722962962962924, 673.5809999999999036 200.1739999999999782, 673.2205185185187020 200.3779629629629824, 672.8571481481480987 200.5870370370370495, 672.4879999999999427 200.7909999999999684, 672.1333935185185737 200.9925601851851695, 671.7781481481481478 201.1904814814814699, 671.4216249999999491 201.3851249999999595, 671.0631851851851479 201.5768518518518135, 670.7021898148148011 201.7660231481481219, 670.3379999999999654 201.9529999999999745, 669.9455555555556430 202.1534444444444603, 669.5584444444444898 202.3538888888888891, 669.1739999999999782 202.5469999999999686, 668.8462812499999472 202.7072187499999529, 668.4595000000000482 202.8957499999999925, 668.0464687500000309 203.0929062499999986, 667.6399999999999864 203.2789999999999679, 667.2970603566529917 203.4371124828531947, 666.9511495198902367 203.5934554183813248, 666.6026296296296323 203.7480370370370508, 666.2518628257888622 203.9008655692729803, 665.8992112482853827 204.0519492455418344, 665.5450370370372184 204.2012962962962774, 665.1897023319615982 204.3489149519889736, 664.8335692729766606 204.4948134430727009, 664.4769999999999754 204.6389999999999816, 662.8369999999999891 205.2789999999999679, 662.4271562500000528 205.4340937499999882, 662.0159999999998490 205.5844999999999914, 661.6025937499999827 205.7304062499999588, 661.1860000000000355 205.8719999999999573, 660.8452880000002096 205.9896320000000003, 660.4916640000000143 206.1156159999999602, 660.1234959999999319 206.2443839999999682, 659.7391520000001037 206.3703679999999849, 659.3369999999999891 206.4879999999999711, 658.8757968749999918 206.6199531249999950, 658.4898750000000973 206.7411250000000109, 658.1322656249999454 206.8579843749999441, 657.7559999999999718 206.9769999999999754, 656.0000000000000000 207.4769999999999754, 655.8949999999999818 207.4769999999999754, 654.2089999999999463 207.9189999999999827, 653.8121851851852853 208.0144444444444787, 653.4204814814814881 208.1098888888888609, 653.0469999999999118 208.1979999999999791, 652.0579999999998790 208.4299999999999784, 651.6834272368213306 208.5132595419659083, 651.3084300494637091 208.5945861410435214, 650.9330184126038148 208.6739776339992716, 650.5572023119420919 208.7514319090720392, 650.1809917439378523 208.8269469060294909, 649.8043967155425662 208.9005206162227637, 649.4274272439345168 208.9721510826399538, 649.0500933562516366 209.0418363999581004, 648.6724050893252524 209.1095747145939754, 648.2943724894126944 209.1753642247533662, 647.9160056119307001 209.2392031804788530, 647.5373145211873407 209.3010898836965907, 647.1583092901144028 209.3610226882612437, 646.7789999999998827 209.4189999999999827, 646.3926239999999552 209.4860240000000147, 646.0025519999999233 209.5486319999999978, 645.6103679999998803 209.6079280000000153, 645.2176559999999199 209.6650160000000085, 644.8259999999999081 209.7209999999999752, 644.4281540000000632 209.7725489999999979, 644.0300320000000056 209.8228320000000053, 643.6313579999998638 209.8719029999999748, 643.2318559999999934 209.9198160000000257, 642.8312499999998408 209.9666249999999650, 642.4292639999997618 210.0123839999999973, 642.0256219999998848 210.0571469999999863, 641.6200479999999970 210.1009680000000230, 641.2122659999998859 210.1439009999999712, 640.8019999999999072 210.1859999999999786, 640.3551838134429772 210.2301700960219364, 639.9267297668038736 210.2697311385459216, 639.5126296296296005 210.3052592592592873, 639.1088751714676164 210.3373305898490742, 638.7114581618654938 210.3665212620027205, 638.3163703703703504 210.3934074074073806, 637.9196035665293039 210.4185651577503222, 637.5171495198901539 210.4425706447187849, 637.1049999999999045 210.4659999999999798, 634.6629999999998972 210.4659999999999798, 634.2597129629630217 210.4711620370370611, 633.8530370370370974 210.4842962962963497, 633.4432499999998072 210.5018749999999841, 633.0306296296296296 210.5203703703703582, 632.6154537037034515 210.5362546296295818, 632.1979999999998654 210.5459999999999923, 630.1629999999998972 210.5459999999999923, 630.1011858528531775 210.1682633680994456, 630.0376470639847639 209.7908130082159346, 629.9723849589123574 209.4136567945477339, 629.9054008991040519 209.0368025951567006, 629.8366962819511627 208.6602582718042811, 629.7662725407383277 208.2840316797874323, 629.6941311446133795 207.9081306677746852, 629.6202735985577874 207.5325630776425214, 629.5447014433538016 207.1573367443117206, 629.4674162555537578 206.7824594955838791, 629.3884196474460850 206.4079391519781836, 629.3077132670222227 206.0337835265682145, 629.2252987979421732 205.6600004248189748, 629.1411779594989184 205.2865976444240630, 629.0553525065836311 204.9135829751429014, 628.9678242296477038 204.5409641986384486, 628.8785949546664824 204.1687490883146268, 628.7876665431007268 203.7969454091543184, 628.6950408918575022 203.4255609175572204, 628.6007199332512982 203.0546033611782661, 628.5047056349632157 202.6840804787657362, 628.4069999999999254 202.3139999999999930, 628.3065750078349083 201.9415662174621673, 628.2057287273235033 201.5692462889950889, 628.1044612875435860 201.1970406911499936, 628.0027728181128168 200.8249499003319443, 627.9006634491872774 200.4529743927989784, 627.7981333114621521 200.0811146446615396, 627.6951825361710462 199.7093711318819373, 627.5918112550857586 199.3377443302737220, 627.4880196005165089 198.9662347155010593, 627.3838077053114830 198.5948427630780770, 627.2791757028570601 198.2235689483683245, 627.1741237270767897 197.8524137465841193, 627.0686519124323013 197.4813776327860637, 626.9627603939222809 197.1104610818822493, 626.8564493070826984 196.7396645686276599, 626.7497187879864669 196.3689885676237452, 626.6425689732436695 195.9984335533177386, 626.5349999999999682 195.6279999999999859, 626.9139924766177501 195.5831123810889665, 627.2927448687075866 195.5362421223888703, 627.6712468044719344 195.4873905074000788, 628.0494879189717494 195.4365588738806423, 628.4274578544105907 195.3837486138096722, 628.8051462604177004 195.3289611733491711, 629.1825427943317663 195.2721980528044696, 629.5596371214844567 195.2134608065831571, 629.9364189154827045 195.1527510431525343, 630.3128778584922429 195.0900704249955027, 630.6890036415194345 195.0254206685650047, 631.0647859646942379 194.9588035442371847, 631.4402145375518103 194.8902208762627311, 631.8152790793144504 194.8196745427171095, 632.1899693191732013 194.7471664754488359, 632.5642749965689973 194.6726986600269242, 632.9381858614734710 194.5962731356863173, 633.3116916746701008 194.5178919952719525, 633.6847822080344486 194.4375573851817762, 634.0574472448137158 194.3552715053076554, 634.4296765799073228 194.2710366089751801, 634.8014600201457824 194.1848550028821592, 635.1727873845703698 194.0967290470352395, 635.5436485047109727 194.0066611546853323, 635.9140332248658751 193.9146537922616176, 636.2839314023786983 193.8207094793039573, 636.6533329079167061 193.7248307883937741, 637.0222276257479734 193.6270203450837926, 637.3906054540188961 193.5272808278260470, 637.7584563050299948 193.4256149678985537, 638.1257701055127427 193.3220255493304762, 638.4925367969053696 193.2165154088259555, 638.8587463356280978 193.1090874356863765, 639.2243886933582644 192.9997445717312985, 639.5894538573049886 192.8884898112177666, 639.9539318304832705 192.7753262007585704, 640.3178126319880903 192.6602568392385137, 640.6810862972669156 192.5432848777297750, 641.0437428783936866 192.4244135194055048, 641.4057724443401867 192.3036460194521737, 641.7671650812486632 192.1809856849804135, 642.1279108927029711 192.0564358749344365, 642.4879999999999427 191.9299999999999784, 644.1279999999999291 191.3259999999999650, 645.2909999999999400 190.8489999999999611, 646.6509999999999536 190.2559999999999718, 647.5929999999999609 189.8139999999999645, 648.1739999999999782 189.5469999999999686, 648.5227281047187944 189.3757953509654044, 648.8702192719115374 189.2020938495475662, 649.2164556246940492 189.0259044319206225, 649.5614193507365144 188.8472361622512494, 649.9050927031805713 188.6660982322319455, 650.2474580015516494 188.4824999606084361, 650.5884976326685774 188.2964507927000284, 650.9281940515503493 188.1079602999139126, 651.2665297823177752 187.9170381792525859, 651.6034874190936534 187.7236942528150507, 651.9390496268970310 187.5279384672915910, 652.2731991425359865 187.3297808934518400, 652.6059187754952973 187.1292317256269371, 652.9371914088206950 186.9263012811849194, 653.2669999999999391 186.7209999999999752, 653.6567407407408155 186.4818518518518715, 654.0409259259259898 186.2351481481481130, 654.4299999999999500 185.9879999999999711, 654.5929999999999609 185.8839999999999577, 654.9871851851852398 185.6240370370370272, 655.3764814814815054 185.3562962962962786, 655.7559999999999718 185.0809999999999604, 656.1043775333519079 184.8347941813776742, 656.4512690627497022 184.5864990390575144, 656.7966620580682502 184.3361235417486341, 657.1405440433109106 184.0836767333050261, 657.4829025970605016 183.8291677323989575, 657.8237253529282498 183.5726057321913629, 658.1630000000000109 183.3139999999999645, 658.5498518518519404 183.0084444444444216, 658.9391481481483197 182.6975555555555388, 659.3260000000000218 182.3839999999999577, 659.6569974696818690 182.1152614756444734, 659.9851052467653290 181.8430023967768534, 660.3102858877249446 181.5672538334920318, 660.6325022830785656 181.2880472541035601, 660.9517176616227516 181.0054145215522681, 661.2678955946288397 180.7193878897702461, 661.5810000000000173 180.4299999999999500, 661.8659375000000864 180.1838593749999688, 662.1497500000000400 179.9331249999999613, 662.4399375000000418 179.6780781249999563, 662.7440000000000282 179.4189999999999543, 663.1305185185186701 179.0730740740740714, 663.4781481481481933 178.7329259259258833, 663.8260000000000218 178.3949999999999534, 664.1060458515985374 178.1156942772400669, 664.3845405851855048 177.8348419154406486, 664.6614756591040987 177.5524515285687812, 664.9368425795338453 177.2685317777639966, 665.2106329007503973 176.9830913710726463, 665.4828382253851942 176.6961390631807944, 665.7534502046826219 176.4076836551457461, 666.0224605387566044 176.1177339941260698, 666.2898609768443521 175.8262989731103119, 666.5556433175601114 175.5333875306441485, 666.8197994091465262 175.2390086505563147, 667.0823211497245211 174.9431713616830280, 667.3432004875418215 174.6458847375910750, 667.6024294212199948 174.3471578962995352, 667.8600000000000136 174.0469999999999402, 668.1076524863998429 173.7537638211852027, 668.3538572946553131 173.4593111034565140, 668.5986084488715733 173.1636489937845056, 668.8419000084368236 172.8667846684939491, 669.0837260681666976 172.5687253330900717, 669.3240807584475078 172.2694782220833076, 669.5629582453788089 171.9690505988138511, 669.8003527309145966 171.6674497552754133, 670.0362584530046206 171.3646830119380979, 670.2706696857338784 171.0607577175707945, 670.5035807394616540 170.7556812490628317, 670.7349859609598752 170.4494610112448640, 670.9648797335496511 170.1421044367091895, 671.1932564772384922 169.8336189856293004, 671.4201106488551432 169.5240121455788085, 671.6454367421843017 169.2132914313498588, 671.8692292881000867 168.9014643847704349, 672.0914828546990520 168.5885385745216070, 672.3121920474322906 168.2745215959535869, 672.5313515092354919 167.9594210709015840, 672.7489559206595686 167.6432446475006088, 672.9650000000000318 167.3259999999999366, 673.2312031250000928 166.9418281249999438, 673.4911250000000109 166.5566249999999400, 673.7467343749999600 166.1693593749999422, 674.0000000000000000 165.7789999999999395, 674.3719999999999573 165.2089999999999463, 674.5893124999998918 164.8675468749999311, 674.8047500000000127 164.5248749999999518, 675.0160624999999754 164.1842656249999379, 675.2210000000000036 163.8489999999999327, 675.5348750000000564 163.3314999999999202, 675.7789999999999964 162.9189999999999259, 675.9398281249999627 162.6480156249999141, 676.1423750000000155 162.3141249999999332, 676.3582343749999382 161.9541718749999291, 676.5589999999999691 161.6049999999999329, 676.7434375000000273 161.2733124999999177, 676.9304999999999382 160.9404999999999291, 677.1175625000000764 160.6054374999999368, 677.3020000000000209 160.2669999999999391, 677.4041549176450872 160.6331126298461811, 677.5057400671915957 160.9993837621015018, 677.6067552027111560 161.3658125100566849, 677.7072000796551947 161.7323979866207253, 677.8070744548558650 162.0991393043234154, 677.9063780865260469 162.4660355753171359, 678.0051107342609384 162.8330859113792144, 678.1032721590374877 163.2002894239139437, 678.2008621232159840 163.5676452239547984, 678.2978803905397172 163.9351524221666239, 678.3943267261363417 164.3028101288477103, 678.4902008965181039 164.6706174539319534, 678.5855026695820698 165.0385735069910993, 678.6802318146114885 165.4066773972368196, 678.7743881022754522 165.7749282335228145, 678.8679713046302595 166.1433251243471432, 678.9609811951193024 166.5118671778542137, 679.0534175485743162 166.8805535018370563, 679.1452801412149256 167.2493832037393702, 679.2365687506502354 167.6183553906578254, 679.3272831558787175 167.9874691693440525, 679.4174231372891199 168.3567236462070298, 679.5069884766605810 168.7261179273150162, 679.5959789571636520 169.0956511183978535, 679.6843943633601839 169.4653223248490690, 679.7722344812045776 169.8351306517280932, 679.8594990980440116 170.2050752037624477, 679.9461880026185554 170.5751550853497633, 680.0323009850623066 170.9453694005601108, 680.1178378369033908 171.3157172531380752, 680.2027983510648710 171.6861977465050302, 680.2871823218652025 172.0568099837611555, 680.3709895450181193 172.4275530676877679, 680.4542198176341117 172.7984261007493103, 680.5368729382201991 173.1694281850957395, 680.6189487066806123 173.5405584225645441, 680.7004469243172480 173.9118159146829612, 680.7813673938303509 174.2831997626701650, 680.8617099193189688 174.6547090674393985, 680.9414743062808384 175.0263429296002755, 681.0206603616136363 175.3981004494607987, 681.0992678936152060 175.7699807270295764, 681.1772967119837858 176.1419828620180965, 681.2547466278185766 176.5141059538428294, 681.3316174536204244 176.8863491016273883, 681.4079090032919339 177.2587114042047460, 681.4836210921381507 177.6311919601194802, 681.5587535368670160 178.0037898676297914, 681.6333061555897075 178.3765042247098904, 681.7072787678209806 178.7493341290519027, 681.7806711944798508 179.1222786780684260, 681.8534832578899341 179.4953369688943781, 681.9257147817797886 179.8685080983893840, 681.9973655912833692 180.2417911631398226, 682.0684355129405958 180.6151852594611853, 682.1389243746975808 180.9886894834000941, 682.2088320059070838 181.3623029307366323, 682.2781582373293077 181.7360246969863340, 682.3469029011314433 182.1098538774026565, 682.4150658308890343 182.4837895669789134, 682.4826468615857493 182.8578308604506333, 682.5496458296139508 183.2319768522976062, 682.6160625727752631 183.6062266367462428, 682.6818969302808000 183.9805793077716203, 682.7471487427515058 184.3550339590998135, 682.8118178522184962 184.7295896842099125, 682.8759041021238545 185.1042455763363819, 682.9394073373205174 185.4790007284711351, 683.0023274040729575 185.8538542333658938, 683.0646641500572969 186.2288051835341776, 683.1264174243619891 186.6038526712536338, 683.1875870774878194 186.9789957885681702, 683.2481729613487005 187.3542336272902276, 683.3081749292715585 187.7295652790029408, 683.3675928359972431 188.1049898350622982, 683.4264265376801859 188.4805063865993588, 683.4846758918894238 188.8561140245225261, 683.5423407576084855 189.2318118395196507, 683.5994209952359597 189.6075989220602764, 683.6559164665857224 189.9834743623978568, 683.7118270348873921 190.3594372505719434, 683.7671525647865565 190.7354866764103463, 683.8218929223451141 191.1116217295314073, 683.8760479750415016 191.4878414993461320, 683.9296175917712617 191.8641450750605486, 683.9826016428472713 192.2405315456776123, 684.0349999999999682 192.6169999999999334, 684.0349999999999682 192.6160000000000139))
</A>
ERROR:shapely.geos:TopologyException: Input geom 1 is invalid: Self-intersection at 684.03487592166005 192.61610852966831
Traceback (most recent call last):
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/bin/vpype", line 8, in <module>
    sys.exit(cli())
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/vpype_cli/cli.py", line 83, in main
    return super().main(args=preprocess_argument_list(args), **extra)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/click/core.py", line 1691, in invoke
    return _process_result(rv)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/click/core.py", line 1628, in _process_result
    value = ctx.invoke(self._result_callback, value, **ctx.params)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/vpype_cli/cli.py", line 222, in process_pipeline
    execute_processors(processors, State())
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/vpype_cli/cli.py", line 306, in execute_processors
    cast(Callable, proc)(state)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/vpype_cli/decorators.py", line 156, in global_processor
    state.document = f(state.document, *new_args, **new_kwargs)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/occult/occult.py", line 177, in occult
    lines, removed_lines = _occult_layer(layer, tolerance, keep_occulted)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/occult/occult.py", line 76, in _occult_layer
    line_arr[gi][1] = line_arr[gi][1].difference(p)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/shapely/geometry/base.py", line 685, in difference
    return geom_factory(self.impl['difference'](self, other))
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/shapely/topology.py", line 72, in __call__
    self._check_topology(err, this, other)
  File "/home/st0rmingbr4in/tmp/adb-draw/vpype/occult/venv/lib/python3.10/site-packages/shapely/topology.py", line 37, in _check_topology
    raise TopologicalError(
shapely.errors.TopologicalError: The operation 'GEOSDifference_r' could not be performed. Likely cause is invalidity of the geometry <shapely.geometry.polygon.Polygon object at 0x7fe326beae00>
```